### PR TITLE
Fix non-deterministic puml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v0.8.13 - ?
 
+- fix non-deterministic plantuml
 
 V0.8.7
 - Remove pytest.ini and move its logic to pyproject.toml

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -582,10 +582,10 @@ def generate_plantuml(
     allrelations = [r for e in mytypes.values() for r in e.get_attributes().values() if isinstance(r, RelationAttribute)]
     if not relations_escape:
         allrelations = [r for r in allrelations if r.get_type().get_full_name() in mytypes]
-    paired = set()
+    paired = dict()
     for r in allrelations:
         if r.end not in paired:
-            paired.add(r)
+            paired[r] = None
 
     def emit_class(entity):
         if not attributes:
@@ -641,8 +641,7 @@ def generate_plantuml(
                 r.get_name(),
             )
 
-    rel = [emit_relation(r) for r in paired]
-    rel.sort()
+    rel = [emit_relation(r) for r in list(paired.keys())]
 
     return "\n".join(classes + inh + rel)
 

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -582,6 +582,9 @@ def generate_plantuml(
     allrelations = [r for e in mytypes.values() for r in e.get_attributes().values() if isinstance(r, RelationAttribute)]
     if not relations_escape:
         allrelations = [r for r in allrelations if r.get_type().get_full_name() in mytypes]
+
+    # We use a dict to benefit from insertion-order and have deterministic puml
+    # see https://github.com/inmanta/graph/pull/100
     paired = dict()
     for r in allrelations:
         if r.end not in paired:
@@ -641,7 +644,7 @@ def generate_plantuml(
                 r.get_name(),
             )
 
-    rel = [emit_relation(r) for r in list(paired.keys())]
+    rel = [emit_relation(r) for r in paired.keys()]
 
     return "\n".join(classes + inh + rel)
 

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -642,6 +642,7 @@ def generate_plantuml(
             )
 
     rel = [emit_relation(r) for r in paired]
+    rel.sort()
 
     return "\n".join(classes + inh + rel)
 

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -583,7 +583,7 @@ def generate_plantuml(
     if not relations_escape:
         allrelations = [r for r in allrelations if r.get_type().get_full_name() in mytypes]
 
-    # We use a dict to benefit from insertion-order in order to have deterministic puml
+    # We use a dict to benefit from insertion-order in order to have deterministic plantuml
     # see https://github.com/inmanta/graph/pull/100
     paired = dict()
     for r in allrelations:

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -583,7 +583,7 @@ def generate_plantuml(
     if not relations_escape:
         allrelations = [r for r in allrelations if r.get_type().get_full_name() in mytypes]
 
-    # We use a dict to benefit from insertion-order and have deterministic puml
+    # We use a dict to benefit from insertion-order in order to have deterministic puml
     # see https://github.com/inmanta/graph/pull/100
     paired = dict()
     for r in allrelations:


### PR DESCRIPTION
# Description

Every time this module is used to generate a class diagram, the order of the relations may be different. This is annoying when we want to generate documentation for a module: if a module's documentation is up-to-date, we shouldn't have any difference when regenerating the documentation, which isn't the case right now.

# Merge procedure

Don't use the github built-in merge, but the process described [here](https://docs.internal.inmanta.com/topics/tasks/commiting_changes_modules.html)

```sh
git pull
git checkout master
git pull
git merge --squash issue/{issue-number}-{short description}
inmanta module commit -m "{Commit Message Here}" -r
git push
git push {tag} # push the tag as well
```

Then close the PR with a reference to the commit

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Version number is bumped to dev version
- [ ] Code is clear and sufficiently documented
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
